### PR TITLE
Fix a calc()

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -132,7 +132,7 @@ settings:
     --background-secondary: hsl(var(--accent-h), calc(var(--bg-s-modifier) + 35%), calc(var(--bg-l-modifier-inverted) + 30%));
     --background-secondary-alt: hsl(var(--accent-h), calc(var(--bg-s-modifier) + 35%), calc(var(--bg-l-modifier-inverted) + 32%));
 
-    --background-modifier-hover: hsla(var(--accent-h), calc(var(--bg-s-modifier) + 30%), calc(var(--bg-l-modifier-inverted)+ 40%), 0.5);
+    --background-modifier-hover: hsla(var(--accent-h), calc(var(--bg-s-modifier) + 30%), calc(var(--bg-l-modifier-inverted) + 40%), 0.5);
     --background-modifier-form-field: var(--interactive-normal);
     --background-modifier-border-hover: hsla(var(--accent-h), 25%, 18%);
     /* #endregion */


### PR DESCRIPTION
For the computation of the `--background-modifier-hover` in dark theme, a space was missing. This breaks the `calc()` function and created a transparent color in the end. Hovering on elements such as in context menus or suggestion menus wouldn't make the color appear.
I looked at all the other calculations in the css and I think it was the only typo like that.