### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Colored Candy",
     "version": "1.0.0",
-    "minAppVersion": "1.0.0",
+    "minAppVersion": "1.13.0",
     "author": "Erika Gozar"
 }

--- a/theme.css
+++ b/theme.css
@@ -454,11 +454,11 @@ div.workspace-tab-header-inner-status-container {
 }
 
 .callout {
-    background-color: rgba(var(--callout-color), 0.125);
+    background-color: color-mix(in srgb, var(--callout-color) 12.5%, transparent);
 }
 
 /* .callout[data-callout="button"] {
-    --callout-color: 143, 69, 255;
+    --callout-color: rgb(143, 69, 255);
     --callout-icon: lucide-shell;
 }
 
@@ -470,6 +470,6 @@ div.workspace-tab-header-inner-status-container {
 
 
 .callout[data-callout="instructions"] {
-    --callout-color: 242, 198, 78;
+    --callout-color: rgb(242, 198, 78);
     --callout-icon: lucide-graduation-cap;
 } */


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
